### PR TITLE
Use only one test app location for all PRs

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,6 +50,6 @@ jobs:
             -e SHINY_ACC_NAME=${{secrets.SHINY_ACC_NAME}}
             -e TOKEN=${{secrets.TOKEN}}
             -e SECRET=${{secrets.SECRET}}
-            -e APP_NAME=${{ steps.set_app_name.outputs.appName }}
+            -e APP_NAME=${{ secrets.TEST_APP_NAME }}
             pullrequestimage
           retry_wait_seconds: 10


### PR DESCRIPTION
This PR will change the workflow so that we only use one test app on Shinyapps.io, instead of having a test app for each PR. Fixes #13.