### PR TITLE
Improve the workforce development tab

### DIFF
--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -549,13 +549,18 @@ unemployment_end_year <-  unemployment_gaps_lm$model$year %>% max()
 unemployment_gaps_lm_2017 <- unemployment_summary_wide %>%
   filter(year >= 2017) %>%
   lm(data = ., formula = gap_to_Wilmington ~ year)
-unemployment_gaps_yearly_change_2017 <- sprintf(fmt = "%.1f%%", unemployment_gaps_lm_2017$coefficients["year"] * 100)
+unemployment_gaps_yearly_change_2017 <- unemployment_gaps_lm_2017$coefficients["year"] * 100
 ```
 
 
 ### Unemployment gaps to Wilmington, since 2017 {data-height=100}
 ```{r}
-valueBox("XXX", icon = "fa-pencil")
+unemployment_box_color <- case_when(unemployment_gaps_yearly_change_2017 >= 0 ~ "warning",
+                                    unemployment_gaps_yearly_change_2017 < 0 ~ "success")
+unemployment_text <- unemployment_gaps_yearly_change_2017 %>%
+  sprintf(fmt = "%+.1f%%", .)
+valueBox(unemployment_text, icon = "fa-briefcase",
+         color = unemployment_box_color)
 ```
 
 
@@ -563,24 +568,24 @@ valueBox("XXX", icon = "fa-pencil")
 ```{r}
 # Create the plot for unemployment gap against Wilmington
 unemployment_plot <- unemployment_summary_wide %>%   
-ggplot(aes(x = year, y = gap_to_Wilmington)) +
+  ggplot(aes(x = year, y = gap_to_Wilmington)) +
   geom_segment(aes(x = year, 
                    xend = year,
                    y = 0, yend = gap_to_Wilmington),
                size = 1.2,
-               color = "#FBB4AE") + 
-  geom_point(size = 5, color = "#FBB4AE") +
-  geom_hline(yintercept = 0, linetype = "dashed") +
-  labs(y = NULL,
-       x = NULL,
+               color = tech_impact_colors("ti_orange")) + 
+  geom_point(size = 5, color = tech_impact_colors("ti_orange")) +
+  geom_hline(yintercept = 0, linetype = "dashed",
+             color = tech_impact_colors("ti_blue")) +
+  annotate("text", label = "Delaware average", x = 2011.5, y = -0.01,
+           color = tech_impact_colors("ti_blue")) + 
+  labs(y = NULL, x = NULL,
        title = "Gaps in unemployment rate vs. Wilmington",
        color = NULL) +
-  scale_y_continuous(labels = scales::label_percent(), limits = c(NA, NA)) + 
+  scale_y_continuous(labels = scales::label_percent()) + 
   scale_x_continuous(breaks = scales::pretty_breaks()) + 
   labs(caption = "Data source: 5-year ACS") +
-  theme_minimal() +
-  theme(panel.grid = element_blank(),
-        plot.margin = margin(1, 2, 1, 2, "cm"))
+  theme_minimal()
 
 # Combine two plots and render
 renderPlot({unemployment_plot}, res = 90)
@@ -598,7 +603,8 @@ unemployment_rates_plot <- unemployment_summary_long %>%
   scale_y_continuous(labels = scales::label_percent()) +
   labs(color = NULL, x = NULL, y = NULL,
        title = "Unemployment rate",
-       caption = "Data source: 5-year ACS")
+       caption = "Data source: 5-year ACS") + 
+      scale_color_manual(values = unname(tech_impact_colors("ti_blue", "ti_orange", "ti_green")) %>% rev())
 
 # Convert to Plotly
 unemployment_rates_plot %>%

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -532,30 +532,15 @@ improved by `r gap_yearly_change_2016_txt` per year from 2016 to 2020.
 
 ```{r}
 # Load Data
-
 unemployment <- read_rds(here("data/processed/workforce_unemployment.rds"))
 unemployment_summary_long <- read_rds(here("data/processed/workforce_unemployment_sum_long.rds"))
 unemployment_summary_wide <- read_rds(here("data/processed/workforce_unemployment_sum_wide.rds"))
 
 ```
 
-
-<!-- Sidebar {.sidebar} -->
-<!-- ----------------------------------------------------------------------- -->
-<!-- ### Workforce Development -->
-
-
-<!-- #### Data Sources -->
-<!-- - [Delaware Open Data - Student Graduation](https://data.delaware.gov/Education/Student-Graduation/t7e6-zcnn) -->
-
-
-
-
 Row 1: Summary {data-height=300}
 -----------------------------------------------------------------------
 ```{r}
-
-
 # Unemployment 
 unemployment_gaps_lm <- lm(data = unemployment_summary_wide,
                            formula = gap_to_Wilmington ~ year)

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -535,7 +535,6 @@ improved by `r gap_yearly_change_2016_txt` per year from 2016 to 2020.
 unemployment <- read_rds(here("data/processed/workforce_unemployment.rds"))
 unemployment_summary_long <- read_rds(here("data/processed/workforce_unemployment_sum_long.rds"))
 unemployment_summary_wide <- read_rds(here("data/processed/workforce_unemployment_sum_wide.rds"))
-
 ```
 
 Row 1: Summary {data-height=300}
@@ -557,7 +556,6 @@ unemployment_gaps_yearly_change_2017 <- sprintf(fmt = "%.1f%%", unemployment_gap
 ### Unemployment gaps to Wilmington 
 ```{r}
 valueBox("XXX", icon = "fa-pencil")
-
 ```
 
 

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -528,7 +528,7 @@ improved by `r gap_yearly_change_2016_txt` per year from 2016 to 2020.
 
 
 
-# Workforce Development
+# Workforce Development {data-orientation=columns}
 
 ```{r}
 # Load Data
@@ -537,7 +537,7 @@ unemployment_summary_long <- read_rds(here("data/processed/workforce_unemploymen
 unemployment_summary_wide <- read_rds(here("data/processed/workforce_unemployment_sum_wide.rds"))
 ```
 
-Row 1: Summary {data-height=300}
+Column 1: Unemployment
 -----------------------------------------------------------------------
 ```{r}
 # Unemployment 
@@ -553,31 +553,15 @@ unemployment_gaps_yearly_change_2017 <- sprintf(fmt = "%.1f%%", unemployment_gap
 ```
 
 
-### Unemployment gaps to Wilmington 
+### Unemployment gaps to Wilmington, since 2017 {data-height=100}
 ```{r}
 valueBox("XXX", icon = "fa-pencil")
 ```
 
 
-### Unemployment
-
-#### Unemployment
-
-- The gaps to the Wilmington's unemployment rate were improving on average
-by `r unemployment_gaps_yearly_change` per year from `r unemployment_start_year` to `r unemployment_end_year`
-
-- However, the gaps are worsening since 2017 by `r unemployment_gaps_yearly_change_2017` per year.
-
-
-
-Row 2: Plots {.tabset .tabset-fade data-height=800}
------------------------------------------------------------------------
-
-### Summary
-
-
-
+### {-}
 ```{r}
+# Create the plot for unemployment gap against Wilmington
 unemployment_plot <- unemployment_summary_wide %>%   
 ggplot(aes(x = year, y = gap_to_Wilmington)) +
   geom_segment(aes(x = year, 
@@ -603,8 +587,7 @@ renderPlot({unemployment_plot}, res = 90)
 ```
 
 
-
-### Unemployment
+### {-}
 
 ```{r}
 unemployment_rates_plot <- unemployment_summary_long %>%   
@@ -621,6 +604,14 @@ unemployment_rates_plot <- unemployment_summary_long %>%
 unemployment_rates_plot %>%
   ggplotly()
 ```
+
+### Notes {data-height=150}
+
+- The gaps to the Wilmington's unemployment rate were improving on average
+by `r unemployment_gaps_yearly_change` per year from `r unemployment_start_year` to `r unemployment_end_year`
+
+- However, the gaps are worsening since 2017 by `r unemployment_text` per year.
+
 
 # Housing {data-navmenu="Details" data-icon="fas fa-house-user"}
 


### PR DESCRIPTION
This PR makes the workforce development tab into the columns orientation and adds the information to the value box about the year-to-year change in the employment rate.

Fixes #27.
