### PR TITLE
Change the title of the app to "WRK Group Dashboard"

### DIFF
--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "WRK Dashboard"
+title: "WRK Group Dashboard"
 output: 
   flexdashboard::flex_dashboard:
     orientation: rows

--- a/deploy.R
+++ b/deploy.R
@@ -16,4 +16,4 @@ deployApp(
   appDir = "app",
   appFiles = NULL, # deploy everything in the app folder
   appName = error_on_missing_name("APP_NAME"),
-  appTitle = "WRK Dashboard")
+  appTitle = "WRK Group Dashboard")


### PR DESCRIPTION
This PR changes the title of the dashboard to "WRK Group Dashboard".

Fixes #56 