### PR TITLE
Convert plots on the Housing tab to Plotly

### DIFF
--- a/components/housing_tenure_valbox.Rmd
+++ b/components/housing_tenure_valbox.Rmd
@@ -1,19 +1,6 @@
 ### Average months since moved in
 
 ```{r}
-# Average months since moved in
-riverside_tenure <- hud_de %>%
-    filter(code == "10003003002") %>%
-  select(year, months_from_movein, pct_occupied, total_units) %>%
-  mutate(location = "riverside")
-
-DE_tenure <- hud_de %>%
-  group_by(year) %>%
-  summarise(months_from_movein = mean(months_from_movein, na.rm = TRUE),
-            pct_occupied = mean(pct_occupied, na.rm = TRUE),
-            total_units = mean(total_units, na.rm = TRUE)) %>%
-  mutate(location = "DE")
-
 # Combine the Riverside and DE data
 tenure_stacked <- riverside_tenure %>%
   bind_rows(DE_tenure)

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -184,7 +184,9 @@ subplot(plot_units_count,
   plotly_disable_zoom() %>%
   plotly_hide_modebar() %>% 
   # Hide legends
-  layout(showlegend = FALSE)
+  hide_legend() %>%
+  # Add caption
+  plotly_caption_hud()
 
 ```
 
@@ -225,10 +227,7 @@ pct_occupied_plot <- pct_occupied_joined %>%
                               size = 14),
                   showarrow = FALSE) %>% 
   # Add caption 
-  add_annotations(x = 1, y = -0.06,
-                  text = "Source: <a href='https://www.huduser.gov/portal/datasets/assthsg.html' target='_blank'>HUD</a>",
-                  showarrow = FALSE, xref ="paper", yref = "paper", 
-                  xanchor = "right", yanchor = "auto") %>%
+  plotly_caption_hud() %>% 
   # Remove axis labels since they are obvious
   # Add "%" suffix to the y-axis
   layout(yaxis = list(title = "",
@@ -308,7 +307,10 @@ plot_ly(x = ~year,
   # Disable zoom
   plotly_disable_zoom() %>%
   # Hide the mode bar
-  plotly_hide_modebar()
+  plotly_hide_modebar() %>%
+  # Add caption 
+  plotly_caption_hud()
+  
 ```
 
 

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -194,6 +194,23 @@ renderPlotly({pct_occupied_plot })
 Column 3: Months since move-in
 -----------------------------------------------------------------------
 
+```{r}
+# Average months since moved in
+riverside_tenure <- hud_de %>%
+    filter(code == "10003003002") %>%
+  select(year, months_from_movein, pct_occupied, total_units) %>%
+  mutate(location = "riverside")
+
+DE_tenure <- hud_de %>%
+  group_by(year) %>%
+  summarise(months_from_movein = mean(months_from_movein, na.rm = TRUE),
+            pct_occupied = mean(pct_occupied, na.rm = TRUE),
+            total_units = mean(total_units, na.rm = TRUE)) %>%
+  mutate(location = "DE")
+
+```
+
+
 ```{r child='components/housing_tenure_valbox.Rmd'}
 # Average months since moved in
 ```

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -123,30 +123,69 @@ Column 1: Available Rental Units
 
 ### Available rental units
 ```{r, housing-total-units-plot}
+# Get the maximum and minimum years for plotting
+min_year <- riverside_total_units %>%
+  pull(year) %>% min
+max_year <- riverside_total_units %>%
+  pull(year) %>% max
+
 # Create a plot for available rental units
-riverside_rental_units_plot <- riverside_total_units %>%
-  ggplot(aes(x = year, y = total_units)) +
-  geom_col(fill = get_wrk_color("green")) +
-  labs(title = "Rental units available in Riverside",
-       y = NULL, x = NULL) +
-  theme_minimal()
+plot_units_count <- riverside_total_units %>%
+  plot_ly(x = ~year,
+          y = ~total_units,
+          color = I(WRK_primary_colors[["green"]])) %>% 
+  # Add barplot and seth the hover text 
+  add_bars(hovertemplate = "In %{x}, Riverside had %{y} units <extra></extra>") %>%
+  # Remove axis title
+  plotly_remove_axis_titles()
 
-riverside_rental_changes_plot <- riverside_total_units %>%
+# Create a plot for percent changes in available units
+plot_units_change <- riverside_total_units %>%
   drop_na(pct_change) %>%
-  ggplot(aes(x = year, y = pct_change)) + 
-  geom_line(color = get_wrk_color("green")) + 
-  geom_point(color = get_wrk_color("green")) +
-  scale_y_continuous(labels = ~paste0(., "%"),
-                     breaks = scales::breaks_pretty()) +
-  labs(title = "Changes in available units",
-       y = NULL, x = NULL) +
-  theme_minimal()
-```
+  plot_ly(x = ~year,
+          y = ~pct_change,
+          color = I(WRK_primary_colors[["green"]])) %>%
+  add_trace(
+    type = "scatter",
+    mode = "markers+lines",
+    hovertemplate = "In %{x}, the number of available units changed %{y:+.1}% from the previous year <extra></extra>"
+  ) %>%
+  # Remove axis titles
+  plotly_remove_axis_titles() %>%
+  # Get the min max for the year
+  summarise(min = min(year), max = max(year)) %>%
+  # Format the ticks
+  layout(xaxis = list(tickvals = ~seq(min, max))) %>%
+  # Gray out the axis line 
+  layout(yaxis = list(zerolinecolor = "#b8b8b8")) %>% 
+  # Format the y axis as percentages
+  layout(yaxis = list(ticksuffix = "%")) %>%
+  # Disable zoom
+  plotly_disable_zoom()
 
-```{r}
-# Render plots and layout with {patchwork}
-renderPlot({ riverside_rental_units_plot / riverside_rental_changes_plot },
-           res = 80)
+
+# Combine the count plot and percent-change plot
+subplot(plot_units_count,
+        plot_units_change,
+        nrows = 2, shareX = TRUE, margin = 0.04) %>% 
+  # Add plot titles to the subplots 
+  plotly_add_subplot_title(text = "Rental units available in Riverside") %>% 
+  plotly_add_subplot_title(text = "Percent changes in available units",
+                           y = 0.45) %>% 
+  # Add back the year labels for the count plot
+  layout(annotations = list(
+    x = min_year:max_year,
+    y = -12,
+    yanchor = "paper",
+    text = min_year:max_year,
+    showarrow = FALSE
+  )) %>% 
+  # Disable zoom & hide the mode bar
+  plotly_disable_zoom() %>%
+  plotly_hide_modebar() %>% 
+  # Hide legends
+  layout(showlegend = FALSE)
+
 ```
 
 

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -135,7 +135,7 @@ plot_units_count <- riverside_total_units %>%
           y = ~total_units,
           color = I(WRK_primary_colors[["green"]])) %>% 
   # Add barplot and seth the hover text 
-  add_bars(hovertemplate = "In %{x}, Riverside had %{y} units <extra></extra>") %>%
+  add_bars(hovertemplate = "In %{x}, Riverside had %{y} public housing units <extra></extra>") %>%
   # Remove axis title
   plotly_remove_axis_titles()
 

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -95,6 +95,21 @@ pct_occupied_joined_lm <- riverside_pct_occupied %>%
 
 # Get the coefficient 
 pct_occupied_riverside_change <- coef(pct_occupied_joined_lm)[["year"]]
+
+
+# Average months since moved in
+riverside_tenure <- hud_de %>%
+  filter(code == "10003003002") %>%
+  select(year, months_from_movein, pct_occupied, total_units) %>%
+  mutate(location = "riverside")
+
+DE_tenure <- hud_de %>%
+  group_by(year) %>%
+  summarise(months_from_movein = mean(months_from_movein, na.rm = TRUE),
+            pct_occupied = mean(pct_occupied, na.rm = TRUE),
+            total_units = mean(total_units, na.rm = TRUE)) %>%
+  mutate(location = "DE")
+
 ```
 
 
@@ -194,25 +209,9 @@ renderPlotly({pct_occupied_plot })
 Column 3: Months since move-in
 -----------------------------------------------------------------------
 
-```{r}
-# Average months since moved in
-riverside_tenure <- hud_de %>%
-    filter(code == "10003003002") %>%
-  select(year, months_from_movein, pct_occupied, total_units) %>%
-  mutate(location = "riverside")
-
-DE_tenure <- hud_de %>%
-  group_by(year) %>%
-  summarise(months_from_movein = mean(months_from_movein, na.rm = TRUE),
-            pct_occupied = mean(pct_occupied, na.rm = TRUE),
-            total_units = mean(total_units, na.rm = TRUE)) %>%
-  mutate(location = "DE")
-
-```
-
 
 ```{r child='components/housing_tenure_valbox.Rmd'}
-# Average months since moved in
+
 ```
 
 

--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -257,23 +257,58 @@ Column 3: Months since move-in
 ### Average months since moved in
 
 ```{r}
-tenure_plot <- tenure_stacked %>%
-  ggplot(aes(x = year, y = months_from_movein,
-             color = location)) + 
-  geom_line() + 
-  geom_point() +
-    scale_color_manual(values = wrk_pal()(2)) +
-    annotate("text", x = 2018, y = 110, label = "Riverside",
-           color = get_wrk_color("green")) +
-  annotate("text", x = 2020, y = 105, label = "Delaware",
-           color = get_wrk_color("blue")) +
-  theme_minimal() + 
-  labs(x = NULL, y = NULL,
-       title = "Months since moved in") +
-  guides(color = "none")
+# Prepare labels for the plot
+tenure_stacked <- tenure_stacked %>% 
+  mutate(location_label = recode(location,
+                                 "riverside" = "Riverside",
+                                 "DE" = "Delaware"))
 
-renderPlot({ tenure_plot }, res = 100)
-
+# Create a Plotly plot for the tenure (average months since move in)
+plot_ly(x = ~year,
+        y = ~months_from_movein,
+        text = ~location_label,
+        hovertemplate = "In %{x} in %{text}, an average family participating in public housing \n had stayed at the same place for %{y:.1f} months <extra></extra>")  %>%
+  # Add trace for Riverside
+  add_trace(
+    data = tenure_stacked %>% filter(location == "riverside"),
+    type = "scatter",
+    mode = "markers+lines",
+    color = I(WRK_primary_colors[["green"]])
+  )  %>% 
+  # Add trace for Delaware
+  add_trace(
+    data = tenure_stacked %>% filter(location == "DE"),
+    type = "scatter",
+    mode = "markers+lines",
+    color = I("gray")
+  )  %>% 
+  # Add annotation labels for the Riverside and Delaware
+  layout(annotations = list(
+    x = 2018, 
+    y = 110, 
+    text = "Riverside",
+    font = list(size = 16, color = get_wrk_color("green")),
+    showarrow = FALSE
+  )) %>%
+  layout(annotations = list(
+    x = 2020, 
+    y = 105, 
+    text = "Delaware",
+    font = list(size = 16, color = "gray"),
+    showarrow = FALSE
+  )) %>%
+  # Remove axes
+  plotly_remove_axis_titles() %>%
+  # Add suffix to the ticks (months)
+  layout(yaxis = list(ticksuffix = " mo.")) %>% 
+  hide_legend() %>%
+  # Add title
+  layout(title = list(text = "Average months since moved in",
+                      xanchor = "left", x = 0)) %>%
+  # Disable zoom
+  plotly_disable_zoom() %>%
+  # Hide the mode bar
+  plotly_hide_modebar()
 ```
 
 

--- a/utils/plotly_utils.R
+++ b/utils/plotly_utils.R
@@ -37,3 +37,11 @@ format_plotly <- function(p) {
     layout(plot_bgcolor = "transparent",
            paper_bgcolor = "transparent")
 }
+
+plotly_remove_axis_titles <- function(p) {
+  # Remove axis title
+  p %>% 
+    layout(yaxis = list(title = ""),
+           xaxis = list(title = ""))
+}
+

--- a/utils/plotly_utils.R
+++ b/utils/plotly_utils.R
@@ -45,3 +45,18 @@ plotly_remove_axis_titles <- function(p) {
            xaxis = list(title = ""))
 }
 
+plotly_add_subplot_title <- function(p, text = "", x = 0, y = 1){
+  p %>% 
+    layout(annotations = list(
+      list(
+        x = x,
+        y = y,
+        text = text,
+        xref = "paper",
+        yref = "paper",
+        xanchor = "left",
+        yanchor = "bottom",
+        showarrow = FALSE
+      )
+    ))
+}

--- a/utils/plotly_utils.R
+++ b/utils/plotly_utils.R
@@ -60,3 +60,12 @@ plotly_add_subplot_title <- function(p, text = "", x = 0, y = 1){
       )
     ))
 }
+
+plotly_caption_hud <- function(p){
+  # Add caption 
+  p %>% 
+    add_annotations(x = 1, y = -0.06,
+                    text = "Source: <a href='https://www.huduser.gov/portal/datasets/assthsg.html' target='_blank'>HUD</a>",
+                    showarrow = FALSE, xref ="paper", yref = "paper", 
+                    xanchor = "right", yanchor = "auto")
+}


### PR DESCRIPTION
This PR converts the plots on the Housing tab to Plotly. Fixes #66.

Specifically, I converted (1) the plot for the available rental units and yearly changes, and (2) the plot for the average months since moved in.

## 2 Challenges about `subplot`

### Axis labels
The plot for the rental units required the use of `subplot`. The difficulty there was to set a shared x-axis (year) while preserving the year labels for both the bar plot and the line plot. Removing the shared x-axis removed alignment, while setting the shared x-axis removed the year labels from the top plot. I circumvented this problem by using annotations. 

### Subplot labels
The `subplot` function does not readily support setting separate titles within the subplot. The official documentation recommends using annotations like [this][1] so I followed the suit. It looks like Plotly 3 supports setting subplot titles from an array Python doc [here][2]. But it may not be implemented yet to R

[1]: https://plotly.com/r/subplots/#:~:text=%23%20Update%20title%0Aannotations%20%3D%20list(%20%0A%20%20list(%20%0A%20%20%20%20x%20%3D%200.2%2C%20%20%0A%20%20%20%20y%20%3D%201.0%2C%20%20%0A%20%20%20%20text%20%3D%20%22Plot%201%22%2C%20%20%0A%20%20%20%20xref%20%3D%20%22paper%22%2C%20%20%0A%20%20%20%20yref%20%3D%20%22paper%22%2C%20%20%0A%20%20%20%20xanchor%20%3D%20%22center%22%2C%20%20%0A%20%20%20%20yanchor%20%3D%20%22bottom%22%2C%20%20%0A%20%20%20%20showarrow%20%3D%20FALSE%20%0A%20%20)%2C

[2]: https://plotly.com/python/subplots/#:~:text=subplot_titles%3D(%22Plot%201%22%2C%20%22Plot%202%22%2C%20%22Plot%203%22%2C%20%22Plot%204%22