### PR TITLE
Remove the horizontal grid lines from the tenure plot

### DIFF
--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -329,7 +329,9 @@ plot_ly(x = ~year,
   # Hide the mode bar
   plotly_hide_modebar() %>%
   # Add caption 
-  plotly_caption_hud()
+  plotly_caption_hud() %>% 
+  # Remove the horizontal grid lines
+  layout(xaxis = list(showgrid = FALSE))
 
 ```
 


### PR DESCRIPTION
This PR removes the vertical grid lines from the plot showing the average months since moved in. Fixes #65.