### PR TITLE
Add a link to this GitHub repo to the dashboard

### DIFF
--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -9,6 +9,8 @@ output:
       primary: "#0c8ccd" #blue
       warning: "#ffc934" #yellow
       navbar-bg: "#00a454" #green
+    navbar:
+      - {icon: "fa-github", href: "https://github.com/de-data-lab/WRK", target: "_blank"}
     logo: "inst/www/logo_40.png"
 runtime: shiny
 ---


### PR DESCRIPTION
This PR adds a link to this GitHub repo to the dashboard. Fix #87.

Note that the link is hard-coded, and thus it may need to get updated when the URL to the repo is changed.