### PR TITLE
Clarify what the employment gap means

### DIFF
--- a/components/workforce_unemployment_valbox.Rmd
+++ b/components/workforce_unemployment_valbox.Rmd
@@ -1,4 +1,4 @@
-### Change in employment gaps to Wilmington since 2017
+### Change in employment rate in WRK Group's census tracts compared to Wilmington since 2017
 
 ```{r}
 employed_box_color <- case_when(employed_gaps_yearly_change_2017 <= 0 ~ "warning",


### PR DESCRIPTION
This PR clarifies the language in the value box for the employment on the workforce development tab. I used the phrase, "employment rate in WRK Group's census tracts", to refer to the fact that the number is an aggregate among the three census tracts. Fixes #91.

This new wording also resolves the issue of the word "gap" being unclear. Fixes #55.

<img width="828" alt="image" src="https://user-images.githubusercontent.com/17035406/179265700-3510f744-ed35-4574-98d9-1508568f387d.png">
