### PR TITLE
Fix the typo for the census tract (60.01 -> 6.01)

### DIFF
--- a/dashboard.Rmd
+++ b/dashboard.Rmd
@@ -604,7 +604,7 @@ tabsetPanel(
   tabPanel("Riverside (30.02)",
            renderPlotly({ employment_plots$Riverside }),
            !!!tab_margin),
-  tabPanel("Eastlake (60.01)",
+  tabPanel("Eastlake (6.01)",
            renderPlotly({ employment_plots$Eastlake }),
            !!!tab_margin),
   tabPanel("Northeast (6.02)",


### PR DESCRIPTION
This PR fixes a typo in the census tract (60.01 → 6.01). Fixes #85.
