### PR TITLE
Replace slashes "/" to make the value boxes human-friendly

### DIFF
--- a/components/education_graduation_valbox.Rmd
+++ b/components/education_graduation_valbox.Rmd
@@ -2,6 +2,6 @@
 
 ```{r}
 gap_yearly_change_2016 %>%
-  sprintf("%+.1f%%/year", .) %>%
+  sprintf("%+.1f%% per year", .) %>%
   valueBox(icon = "fa-graduation-cap")
 ```

--- a/components/education_literacy_valbox.Rmd
+++ b/components/education_literacy_valbox.Rmd
@@ -3,6 +3,6 @@
 ```{r}
 # Render value box
 eastside_ELA_gap_coeff %>%
-  sprintf("%+.1f%%/year", .) %>%
+  sprintf("%+.1f%% per year", .) %>%
   valueBox(icon = "fa-book-open")
 ```

--- a/components/education_math_valbox.Rmd
+++ b/components/education_math_valbox.Rmd
@@ -3,6 +3,6 @@
 ```{r}
 # Create a value box for math gap
 eastside_math_gap_coeff %>%
-  sprintf("%+.1f%%/year", .) %>%
+  sprintf("%+.1f%% per year", .) %>%
   valueBox(icon = "fas fa-calculator")
 ```

--- a/components/events_per_month_valbox.Rmd
+++ b/components/events_per_month_valbox.Rmd
@@ -3,6 +3,6 @@
 ```{r}
 events_monthly_count %>% 
   round(1) %>%
-  paste0(" events/month") %>%
+  paste0(" events per month") %>%
   valueBox(icon = "fa-calendar-plus")
 ```

--- a/components/events_yearly_hours_valbox.Rmd
+++ b/components/events_yearly_hours_valbox.Rmd
@@ -3,6 +3,6 @@
 ```{r}
 events_yearly_hours %>% 
   round(1) %>%
-  paste0(" hours/year") %>%
+  paste0(" hours per year") %>%
   valueBox(icon = "fa-clock")
 ```

--- a/components/housing_occupied_valbox.Rmd
+++ b/components/housing_occupied_valbox.Rmd
@@ -4,7 +4,7 @@
 # Get the text to be rendered
 pct_occupied_box_text <- pct_occupied_riverside_change %>% 
   round(1) %>%
-  paste0("%/year")
+  paste0("% per year")
 # Change color of the infobox depending on direction
 pct_occupied_color <- case_when(pct_occupied_riverside_change >= 0 ~ "success",
                                 TRUE ~ "warning")

--- a/components/housing_tenure_valbox.Rmd
+++ b/components/housing_tenure_valbox.Rmd
@@ -13,7 +13,7 @@ riverside_tenure_coef <- coef(riverside_tenure_lm)[["year"]]
 
 riverside_tenure_text <- riverside_tenure_coef %>%
   round(1) %>%
-  sprintf("%+.1fmo/year", .)
+  sprintf("%+.1f months per year", .)
 
 valueBox(riverside_tenure_text, icon = "fas fa-calendar-alt")
 ```

--- a/components/housing_units_count_change_valbox.Rmd
+++ b/components/housing_units_count_change_valbox.Rmd
@@ -3,7 +3,7 @@
 ```{r}
 total_units_change_box_text <- riverside_total_units_coef %>%
   round(1) %>%
-  paste0("/year")
+  paste0(" per year")
 
 units_change_valbox_color <- case_when(riverside_total_units_coef >= 0 ~ "success",
                                 TRUE ~ "warning")

--- a/components/workforce_unemployment_valbox.Rmd
+++ b/components/workforce_unemployment_valbox.Rmd
@@ -7,7 +7,7 @@ unemployment_text <- employed_gaps_yearly_change_2017 %>%
   sprintf(fmt = "%+.1f%%", .)
 
 unemployment_text %>%  
-  paste0("/year") %>%
+  paste0(" per year") %>%
   valueBox(icon = "fa-briefcase",
            color = employed_box_color)
 ```


### PR DESCRIPTION
This PR replaces slashes ("/") in the value boxes with ("per") to increase readability. Fixes #62 

This PR also spells out "mo" as "months" to achieve the same goal. 